### PR TITLE
Cambios del documento de revisión del CSP

### DIFF
--- a/roh-v2.owl
+++ b/roh-v2.owl
@@ -1686,6 +1686,69 @@ by creating a research management system with semantic capacities based on seman
     
 
 
+    <!-- http://purl.org/roh/mirror/vcard#adr -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#adr">
+        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#hasAddress"/>
+        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
+        <rdfs:label xml:lang="en">address</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#email -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#email">
+        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#hasEmail"/>
+        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
+        <rdfs:label xml:lang="en">email</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#hasAddress -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasAddress">
+        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Address"/>
+        <rdfs:comment xml:lang="en">To specify the components of the delivery address for the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">has address</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#hasEmail -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasEmail">
+        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Email"/>
+        <rdfs:comment xml:lang="en">To specify the electronic mail address for communication with the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">has email</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#hasName -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasName">
+        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#n"/>
+        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Name"/>
+        <rdfs:comment xml:lang="en">To specify the components of the name of the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">has name</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#n -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#n">
+        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
+        <rdfs:label xml:lang="en">name</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -2778,6 +2841,17 @@ by creating a research management system with semantic capacities based on seman
     
 
 
+    <!-- http://purl.org/roh/mirror/vcard#locality -->
+
+    <owl:DatatypeProperty rdf:about="http://purl.org/roh/mirror/vcard#locality">
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment xml:lang="en">The locality (e.g. city or town) associated with the address of the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">locality</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://purl.org/roh/mirror/vivo#abbreviation -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/roh/mirror/vivo#abbreviation">
@@ -3103,6 +3177,12 @@ Definition source: http://isiwebofknowledge.com/researcherid/</obo:IAO_0000112>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/roh/mirror/vcard#locality"/>
+                <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.org/roh/mirror/vivo#contactInformation"/>
                 <owl:allValuesFrom rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
             </owl:Restriction>
@@ -3123,6 +3203,13 @@ Definition source: http://isiwebofknowledge.com/researcherid/</obo:IAO_0000112>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.org/roh/mirror/vivo#identifier"/>
                 <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/roh/mirror/vcard#locality"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Only use if no specific subclasses of event:Event are appropriate.</obo:IAO_0000112>
@@ -6491,6 +6578,18 @@ Based on obo-bfo:Role also used in VIVO, it defines roles. The object property r
     
 
 
+    <!-- http://purl.org/roh/mirror/vcard#Address -->
+
+    <owl:Class rdf:about="http://purl.org/roh/mirror/vcard#Address"/>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#Email -->
+
+    <owl:Class rdf:about="http://purl.org/roh/mirror/vcard#Email"/>
+    
+
+
     <!-- http://purl.org/roh/mirror/vcard#Group -->
 
     <owl:Class rdf:about="http://purl.org/roh/mirror/vcard#Group">
@@ -6535,6 +6634,12 @@ Based on obo-bfo:Role also used in VIVO, it defines roles. The object property r
         <rdfs:label xml:lang="es">Localización</rdfs:label>
         <rdfs:label xml:lang="en">Location</rdfs:label>
     </owl:Class>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#Name -->
+
+    <owl:Class rdf:about="http://purl.org/roh/mirror/vcard#Name"/>
     
 
 
@@ -8412,4 +8517,3 @@ Contents
 
 
 <!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
-

--- a/roh-v2.owl
+++ b/roh-v2.owl
@@ -1434,6 +1434,69 @@ by creating a research management system with semantic capacities based on seman
     
 
 
+    <!-- http://purl.org/roh/mirror/vcard#adr -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#adr">
+        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#hasAddress"/>
+        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
+        <rdfs:label xml:lang="en">address</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#email -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#email">
+        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#hasEmail"/>
+        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
+        <rdfs:label xml:lang="en">email</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#hasAddress -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasAddress">
+        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Address"/>
+        <rdfs:comment xml:lang="en">To specify the components of the delivery address for the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">has address</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#hasEmail -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasEmail">
+        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Email"/>
+        <rdfs:comment xml:lang="en">To specify the electronic mail address for communication with the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">has email</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#hasName -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasName">
+        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#n"/>
+        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Name"/>
+        <rdfs:comment xml:lang="en">To specify the components of the name of the object</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
+        <rdfs:label xml:lang="en">has name</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.org/roh/mirror/vcard#n -->
+
+    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#n">
+        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
+        <rdfs:label xml:lang="en">name</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.org/roh/mirror/vivo#affiliatedOrganization -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vivo#affiliatedOrganization">
@@ -1682,69 +1745,6 @@ by creating a research management system with semantic capacities based on seman
         <rdfs:comment xml:lang="en">The cited entity is cited as a data source by the citing entity.</rdfs:comment>
         <rdfs:label xml:lang="es">citado como fuente de datos por</rdfs:label>
         <rdfs:label xml:lang="en">is cited as data source by</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.org/roh/mirror/vcard#adr -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#adr">
-        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#hasAddress"/>
-        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
-        <rdfs:label xml:lang="en">address</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.org/roh/mirror/vcard#email -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#email">
-        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#hasEmail"/>
-        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
-        <rdfs:label xml:lang="en">email</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.org/roh/mirror/vcard#hasAddress -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasAddress">
-        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Address"/>
-        <rdfs:comment xml:lang="en">To specify the components of the delivery address for the object</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
-        <rdfs:label xml:lang="en">has address</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.org/roh/mirror/vcard#hasEmail -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasEmail">
-        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Email"/>
-        <rdfs:comment xml:lang="en">To specify the electronic mail address for communication with the object</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
-        <rdfs:label xml:lang="en">has email</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.org/roh/mirror/vcard#hasName -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#hasName">
-        <owl:equivalentProperty rdf:resource="http://purl.org/roh/mirror/vcard#n"/>
-        <rdfs:range rdf:resource="http://purl.org/roh/mirror/vcard#Name"/>
-        <rdfs:comment xml:lang="en">To specify the components of the name of the object</rdfs:comment>
-        <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2006/vcard/ns"/>
-        <rdfs:label xml:lang="en">has name</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://purl.org/roh/mirror/vcard#n -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/roh/mirror/vcard#n">
-        <rdfs:comment xml:lang="en">This object property has been mapped</rdfs:comment>
-        <rdfs:label xml:lang="en">name</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -3803,6 +3803,12 @@ The previous short definition was: &quot;An arbitrary classification of a space/
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/roh/mirror/vivo#relatedBy"/>
+                <owl:allValuesFrom rdf:resource="http://purl.org/roh#Dossier"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.org/roh/mirror/vivo#identifier"/>
                 <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
@@ -4051,6 +4057,14 @@ A roh:FundingSource roh:feeds a roh:Funding with funds to sponsor some projects.
         <rdfs:comment xml:lang="en">An amount of money that is borrowed, often from a bank or a funding organization, and has to be paid back, usually together with an extra amount of money that you have to pay as a charge for borrowing.</rdfs:comment>
         <rdfs:label xml:lang="en">Loan</rdfs:label>
         <rdfs:label xml:lang="es">Préstamo</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.org/roh#ManagementUnit -->
+
+    <owl:Class rdf:about="http://purl.org/roh#ManagementUnit">
+        <rdfs:subClassOf rdf:resource="http://purl.org/roh/mirror/foaf#Organization"/>
     </owl:Class>
     
 
@@ -7655,6 +7669,12 @@ Contents
     <owl:Class rdf:about="http://purl.org/roh/mirror/vivo#Project">
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/roh#fundedBy"/>
+                <owl:allValuesFrom rdf:resource="http://purl.org/roh#FundingProgram"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.org/roh#hasContract"/>
                 <owl:allValuesFrom rdf:resource="http://purl.org/roh#ProjectContract"/>
             </owl:Restriction>
@@ -7675,6 +7695,12 @@ Contents
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.org/roh#hasProjectCategorization"/>
                 <owl:allValuesFrom rdf:resource="http://purl.org/roh#ProjectClassification"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/roh#isSupportedBy"/>
+                <owl:allValuesFrom rdf:resource="http://purl.org/roh#Funding"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -8517,3 +8543,4 @@ Contents
 
 
 <!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+


### PR DESCRIPTION
- Alta restricción "only" de vivo:Project para roh:isSupportedBy con roh:Funding
- Necesario vincular roh:FundingProgram a vivo:Project directamente, sino un proyecto que es de modalidad SOLICITUD (no aprobado) no puede saberse a qué convocatoria fue enviado.
- Vincular FundingProgram con Dossier
- Añadimos en jerarquía de Organization ManagementUnit